### PR TITLE
augment the build script (anthony-suggestion)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "[ \"$(uname)\" != \"Linux\" ] && exit 0; next build",
     "start": "next start",
     "format": "prettier . --check --cache --cache-location=\"node_modules/.cache/prettiercache\"",
     "format:fix": "prettier . --write --cache --cache-location=\"node_modules/.cache/prettiercache\" --log-level=warn",

--- a/packages/transpiled/package.json
+++ b/packages/transpiled/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "cargo build",
+    "build": "[ \"$(uname)\" != \"Windows_NT\" ] && exit 0; cargo build",
     "bindings": "cross test --target x86_64-pc-windows-gnu && sh ./bindings.sh",
     "format": "prettier . --check --cache --cache-location=\"node_modules/.cache/prettiercache\"",
     "format:fix": "prettier . --write --cache --cache-location=\"node_modules/.cache/prettiercache\" --log-level=warn",

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,7 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+      "cache": false
     },
     "topo": {
       "dependsOn": ["^topo"]


### PR DESCRIPTION
This hack works as it exit before control reaches turbo. Suggested by @anthonyshew [Here](https://github.com/vercel/turbo/discussions/6203#discussioncomment-7962330).

> It seems that this could also be solved by making a quick script in the package's package.json that says "if (TARGET_OS) build, else exit 0". This would make it so that that task passes, at least, but you may find you need to apply cache: false to this specific task as a result of this strategy. I don't know the deeper specifics of your repo so can't speak a perfect solution.

